### PR TITLE
Update hacker.ruleset

### DIFF
--- a/data/nation/hacker.ruleset
+++ b/data/nation/hacker.ruleset
@@ -28,6 +28,7 @@ leaders = {
  "Alan Kay",            "Male"
  "Bjarne Stroustrup",   "Male"
  "Niklaus Wirth",       "Male"
+ "Terry Davis",         "Male"
 }
 
 ruler_titles = {


### PR DESCRIPTION
Adding Terry Davis as a hacker.

I'm not 100% on the legalities of including "TempleOS" in this project, but we do already have a trademark in the source code (line 67) and TempleOS is in the public domain... still, it's very tempting to add "TempleOS" as a city.