### PR TITLE
Fix divide by zero error in mapimg

### DIFF
--- a/common/mapimg.c
+++ b/common/mapimg.c
@@ -2149,8 +2149,8 @@ static bool img_save_magickwand(const struct img *pimg,
     }
 
     /* Show a line displaying the colors of alive players */
-    plrwidth = map_width / player_slot_count();
-    plroffset = (map_width - plrwidth * player_slot_count()) / 2;
+    plrwidth = map_width / MIN(map_width, player_count());
+    plroffset = (map_width - MIN(map_width, plrwidth * player_count())) / 2;
 
     imw = NewPixelRegionIterator(mw, IMG_BORDER_WIDTH,
                                  IMG_BORDER_HEIGHT + IMG_TEXT_HEIGHT


### PR DESCRIPTION
Use player_count() instead of player_slot_count() so player colors
are sized meaningfully. Ensure no division error, or negative
offset is used.

See hrm [Bug #707912](http://www.hostedredmine.com/issues/707912)

This incorporates a downstream patch, and allow removal of the patch from fc-web: freeciv/freeciv-web#95