### PR TITLE
1.  Removed a bug in ai/default/daicity.c, function dai_city_choose_build

### DIFF
--- a/ai/default/aihand.c
+++ b/ai/default/aihand.c
@@ -211,7 +211,7 @@ enum celebration {
 static void dai_manage_taxes(struct ai_type *ait, struct player *pplayer)
 {
   int maxrate = (has_handicap(pplayer, H_RATES)
-                 ? get_player_bonus(pplayer, EFT_MAX_RATES) : 100);
+                 ? MIN(80, get_player_bonus(pplayer, EFT_MAX_RATES)) : 80);
   struct research *research = research_get(pplayer);
   enum celebration celebrate = AI_CELEBRATION_UNCHECKED;
   struct adv_data *ai = adv_data_get(pplayer, NULL);

--- a/ai/default/daicity.c
+++ b/ai/default/daicity.c
@@ -256,8 +256,7 @@ static void dai_city_choose_build(struct ai_type *ait, struct player *pplayer,
   struct ai_city *city_data = def_ai_city_data(pcity, ait);
 
   if (has_handicap(pplayer, H_AWAY)
-      && city_built_last_turn(pcity)
-      && city_data->urgency == 0) {
+      || (!city_built_last_turn(pcity) && city_data->urgency < 2)) {
     /* Don't change existing productions unless we have to. */
     return;
   }


### PR DESCRIPTION
which prevented correct function access logic. With the new code
AI-players build more reliably and don't break building wonders at
random any more.

2.  Made improvement in corrupted code in ai/default/aihand.c function
dai_manage_taxes. Calculation of resource distribution
(tax/research/lux) is corrupted; my modification sets a maximum of 80%
for each category, so the worst is avoided, namely that no research
takes place with AI-players.

NOTE: The commit comment has the file names exchanged (error).