### PR TITLE
Only include sys/random.h for getentropy()

### DIFF
--- a/utility/randseed.c
+++ b/utility/randseed.c
@@ -26,7 +26,7 @@
 #include <fcntl.h>
 #include <stdint.h>
 #include <string.h>
-#ifdef HAVE_SYS_RANDOM_H
+#if defined(HAVE_SYS_RANDOM_H) && defined(HAVE_GETENTROPY)
 #include <sys/random.h>
 #endif
 #include <sys/stat.h>


### PR DESCRIPTION
This fixes a build failure on older OS X versions, which have `sys/random.h` but not `getentropy()`. Instead the header declares some nonstandard functions which unfortunately use some types in their declarations that may not always be available, depending on what headers were previously included.

The simplest solution seems to be to just not include the header in that situation. I don't know if `sys/random.h` is used for anything else on other platforms; if so, this could be be modified to also check for `__APPLE__`.