### PR TITLE
doc: fix small typo

### DIFF
--- a/common/aicore/path_finding.c
+++ b/common/aicore/path_finding.c
@@ -1471,7 +1471,7 @@ pf_danger_map_adjust_cost(const struct pf_parameter *params,
   D. NS_PROCESSED: Now, we are sure we have the best path.
   E. NS_WAITING: The safe node (never the dangerous ones) is re-inserted in
      the priority queue, as explained above (2.). We need to consider if
-     waiting for full moves open or not new possibilities for moving accross
+     waiting for full moves open or not new possibilities for moving across
      dangerous areas.
   F. NS_PROCESSED: When finished to consider waiting at the node, revert the
      status to NS_PROCESSED.


### PR DESCRIPTION
Fixed small typo in code commenting!
`accross` -> `across`
Thanks.