### PR TITLE
Fix heap-use-after-free

### DIFF
--- a/server/cityturn.c
+++ b/server/cityturn.c
@@ -1085,8 +1085,9 @@ static void city_populate(struct city *pcity, struct player *nationality)
 		    city_link(pcity));
     }
     city_reset_foodbox(pcity, city_size_get(pcity) - 1);
-    city_reduce_size(pcity, 1, NULL, "famine");
-    pcity->had_famine = TRUE;
+    if (city_reduce_size(pcity, 1, NULL, "famine")) {
+      pcity->had_famine = TRUE;
+    }
   }
 }
 


### PR DESCRIPTION
Fix heap-use-after-free

https://github.com/freeciv/freeciv/blob/master/server/cityturn.c#L1088-L1089

city_reduce_size() can remove (free) city. its return code must be checked.

**there is similar code elsewhere, like https://github.com/freeciv/freeciv/blob/master/server/cityturn.c#L3874-L3875 that i didnt check further.**

```
==119264==ERROR: AddressSanitizer: heap-use-after-free on address 0x61d0000119db at pc 0x561d1a58bad2 bp 0x7ffd96773b40 sp 0x7ffd96773b30
WRITE of size 1 at 0x61d0000119db thread T0
    #0 0x561d1a58bad1 in city_populate /home/michael/usr/src/freeciv/server/cityturn.c:1089
    #1 0x561d1a5a0f68 in update_city_activity /home/michael/usr/src/freeciv/server/cityturn.c:3397
    #2 0x561d1a586f3b in update_city_activities /home/michael/usr/src/freeciv/server/cityturn.c:655
    #3 0x561d1a3ee027 in end_phase /home/michael/usr/src/freeciv/server/srv_main.c:1470
    #4 0x561d1a3f9732 in srv_running /home/michael/usr/src/freeciv/server/srv_main.c:2935
    #5 0x561d1a3fe790 in srv_main /home/michael/usr/src/freeciv/server/srv_main.c:3503
    #6 0x561d1a3d3e3d in main /home/michael/usr/src/freeciv/server/civserver.c:388
    #7 0x7f73d1e3c28f  (/usr/lib/libc.so.6+0x2328f)
    #8 0x7f73d1e3c349 in __libc_start_main (/usr/lib/libc.so.6+0x23349)
    #9 0x561d1a3d1044 in _start ../sysdeps/x86_64/start.S:115

0x61d0000119db is located 347 bytes inside of 2400-byte region [0x61d000011880,0x61d0000121e0)
freed by thread T0 here:
    #0 0x7f73d2ebe672 in __interceptor_free /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x561d1aa37036 in destroy_city_virtual /home/michael/usr/src/freeciv/common/city.c:3458
    #2 0x561d1aa6e88b in game_remove_city /home/michael/usr/src/freeciv/common/game.c:223
    #3 0x561d1a56947e in remove_city /home/michael/usr/src/freeciv/server/citytools.c:1869
    #4 0x561d1a587e1c in city_reduce_size /home/michael/usr/src/freeciv/server/cityturn.c:767
    #5 0x561d1a58ba34 in city_populate /home/michael/usr/src/freeciv/server/cityturn.c:1088
    #6 0x561d1a5a0f68 in update_city_activity /home/michael/usr/src/freeciv/server/cityturn.c:3397
    #7 0x561d1a586f3b in update_city_activities /home/michael/usr/src/freeciv/server/cityturn.c:655
    #8 0x561d1a3ee027 in end_phase /home/michael/usr/src/freeciv/server/srv_main.c:1470
    #9 0x561d1a3f9732 in srv_running /home/michael/usr/src/freeciv/server/srv_main.c:2935
    #10 0x561d1a3fe790 in srv_main /home/michael/usr/src/freeciv/server/srv_main.c:3503
    #11 0x561d1a3d3e3d in main /home/michael/usr/src/freeciv/server/civserver.c:388
    #12 0x7f73d1e3c28f  (/usr/lib/libc.so.6+0x2328f)
```