### PR TITLE
Update han.ruleset

### DIFF
--- a/data/nation/han.ruleset
+++ b/data/nation/han.ruleset
@@ -2,7 +2,7 @@
 
 name   = _("Han")
 plural = _("?plural:Han")
-groups = "Ancient", "Medieval", "Early Modern", "Asian"
+groups = "Ancient", "Medieval", "Asian"
 legend = _("The Han people are the majority ethnic group in China, tracing\
  their lineage back to \"Yandi\" (the Yan Emperor) and \"Huangdi\" (the\
  Yellow Emperor), legendary god-kings of prehistory.")


### PR DESCRIPTION
The han dynasty fell around 220 AD, so it never made it to the early modern era, and hardly the middle ages.