### PR TITLE
Changed Despotism title in portuguese.ruleset

### DIFF
--- a/data/nation/portuguese.ruleset
+++ b/data/nation/portuguese.ruleset
@@ -25,7 +25,7 @@ leaders = {
 
 ruler_titles = {
  "government",      "male_title",           "female_title"
- "Despotism",       _("Viscount %s"),       _("Viscountess %s")
+ "Despotism",       _("Count %s"),          _("Countess %s")
  "Fundamentalism",  _("Patriarch %s"),      _("Mother Superior %s")
 }
 


### PR DESCRIPTION
The Portucalense county was a county and not a viscounty.