### PR TITLE
Add new policies to Sandbox for veteran-builds and production

### DIFF
--- a/data/sandbox/effects.ruleset
+++ b/data/sandbox/effects.ruleset
@@ -931,6 +931,81 @@ reqs   =
       "OutputType", "Science", "Local"
     }
 
+[effect_polluting_productivity_prod]
+type    = "Output_Bonus_2"
+value   = 1
+multiplier = "Polluting Productivity"
+reqs   =
+    { "type", "name", "range"
+      "OutputType", "Shield", "Local"
+    }
+
+[effect_polluting_productivity_pol]
+type    = "Pollu_Prod_Pct"
+value   = 5
+multiplier = "Polluting Productivity"
+reqs   =
+    { "type", "name", "range"
+    }
+
+[effect_military_training_duration_cost]
+type    = "Unit_Build_Cost_Pct"
+value   = 25
+multiplier = "Military Training Duration"
+reqs   =
+    { "type", "name", "range", "present"
+      "UnitFlag", "NonMil", "Local", FALSE
+      "UnitFlag", "NoVeteran", "Local", FALSE
+    }
+
+[effect_military_training_duration_veterancy]
+type    = "Veteran_Build"
+value   = 1
+multiplier = "Military Training Duration"
+reqs   =
+    { "type", "name", "range", "present"
+      "UnitFlag", "NonMil", "Local", FALSE
+      "UnitFlag", "NoVeteran", "Local", FALSE
+    }
+
+[effect_diplomatic_training_duration_cost]
+type    = "Unit_Build_Cost_Pct"
+value   = 25
+multiplier = "Diplomatic Training Duration"
+reqs   =
+    { "type", "name", "range"
+      "UnitFlag", "Diplomat", "Local"
+    }
+
+[effect_diplomatic_training_duration_veterancy]
+type    = "Veteran_Build"
+value   = 1
+multiplier = "Diplomatic Training Duration"
+reqs   =
+    { "type", "name", "range"
+      "UnitFlag", "Diplomat", "Local"
+    }
+
+; Should be "Workers" instead of "Transform" flag, but "Workers" cannot be used here.
+[effect_civil_training_duration_cost]
+type    = "Unit_Build_Cost_Pct"
+value   = 25
+multiplier = "Civil Training Duration"
+reqs   =
+    { "type", "name", "range"
+      "UnitFlag", "Transform", "Local"
+    }
+
+; Should be "Workers" instead of "Transform" flag, but "Workers" cannot be used here.
+[effect_civil_training_duration_veterancy]
+type    = "Veteran_Build"
+value   = 1
+multiplier = "Civil Training Duration"
+reqs   =
+    { "type", "name", "range"
+      "UnitFlag", "Transform", "Local"
+    }
+
 ; Govs with 1 free unit
 [effect_upkeep_free_mil_1]
 type    = "Make_Content_Mil"

--- a/data/sandbox/governments.ruleset
+++ b/data/sandbox/governments.ruleset
@@ -447,3 +447,56 @@ Each step of personal freedom you allow your citizens yields a 10% \
 increase in science output, but makes an additional citizen unhappy \
 for every aggressively deployed military unit.\
 ")
+
+[multiplier_polluting_productivity]
+name      = _("Polluting Productivity")
+start     = 0
+stop      = 10
+step      = 1
+default   = 0
+; /* xgettext:no-c-format */
+helptext  = _("\
+Each step of polluting productivity increases a cities shield \
+production by 1%, but also increases all pollution related to \
+shields by 5%.\
+")
+
+[multiplier_military_training_duration]
+name      = _("Military Training Duration")
+start     = 0
+stop      = 2
+step      = 1
+default   = 0
+; /* xgettext:no-c-format */
+helptext  = _("\
+Each step increases newly built military units veterancy level \
+by 1, but also increases the costs of the unit by 25% due to \
+the additional training.\
+")
+
+[multiplier_diplomatic_training_duration]
+name      = _("Diplomatic Training Duration")
+start     = 0
+stop      = 2
+step      = 1
+default   = 0
+; /* xgettext:no-c-format */
+helptext  = _("\
+Each step increases newly built diplomatic units veterancy \
+level by 1, but also increases the costs of the unit by 25% \
+due to the additional training.\
+")
+
+[multiplier_civil_training_duration]
+name      = _("Civil Training Duration")
+start     = 0
+stop      = 2
+step      = 1
+default   = 0
+; /* xgettext:no-c-format */
+helptext  = _("\
+Each step increases newly built civil (workers, engineers) \
+units veterancy level by 1, but also increases the costs of \
+the unit by 25% due to the additional training.\
+")
+


### PR DESCRIPTION
Adds policies for:
- Up to 10% more production (for up to 50% more pollution)
- Higher veteran levels for new units (for 25% additional build costs per level)

Sandbox is a nice ruleset to demonstrate new features and adding some more policies hopefully demonstrates the usefulness of the policies feature.