### PR TITLE
Fix misspellings

### DIFF
--- a/client/gui-gtk-3.22/editprop.c
+++ b/client/gui-gtk-3.22/editprop.c
@@ -6380,7 +6380,7 @@ void property_editor_reload(struct property_editor *pe,
   should be freed by property_filter_free when no longed needed.
 
   The filter string is '|' ("or") separated list of '&' ("and") separated
-  lists of patterns. A pattern may be preceeded by '!' to have its result
+  lists of patterns. A pattern may be preceded by '!' to have its result
   negated.
 
   NB: If you change the behaviour of this function, be sure to update

--- a/client/gui-gtk-4.0/editprop.c
+++ b/client/gui-gtk-4.0/editprop.c
@@ -6406,7 +6406,7 @@ void property_editor_reload(struct property_editor *pe,
   should be freed by property_filter_free when no longed needed.
 
   The filter string is '|' ("or") separated list of '&' ("and") separated
-  lists of patterns. A pattern may be preceeded by '!' to have its result
+  lists of patterns. A pattern may be preceded by '!' to have its result
   negated.
 
   NB: If you change the behaviour of this function, be sure to update

--- a/client/gui-gtk-5.0/editprop.c
+++ b/client/gui-gtk-5.0/editprop.c
@@ -6406,7 +6406,7 @@ void property_editor_reload(struct property_editor *pe,
   should be freed by property_filter_free when no longed needed.
 
   The filter string is '|' ("or") separated list of '&' ("and") separated
-  lists of patterns. A pattern may be preceeded by '!' to have its result
+  lists of patterns. A pattern may be preceded by '!' to have its result
   negated.
 
   NB: If you change the behaviour of this function, be sure to update

--- a/translations/core/check_po.pl
+++ b/translations/core/check_po.pl
@@ -78,7 +78,7 @@ sub print_one {
     print "  $name \"", join("\"\n  \"", @_), "\"\n";
 }
 
-# Print a problem (args like print()), preceeded by entry unless
+# Print a problem (args like print()), preceded by entry unless
 # we have already printed that: label, and msgid and msgstr.
 #
 sub print_problem {

--- a/utility/inputfile.c
+++ b/utility/inputfile.c
@@ -30,7 +30,7 @@
   The tokens recognised are as follows:
   (Single quotes are delimiters used here, but are not part of the
   actual tokens/strings.)
-  Most tokens can be preceeded by optional whitespace; exceptions
+  Most tokens can be preceded by optional whitespace; exceptions
   are section_name and entry_name.
 
   section_name:  '[foo]'


### PR DESCRIPTION
 Codebase uses word "preceeded" in several places, instead of correct "preceded"