### PR TITLE
(PoC) Speedup freeciv-server cold start by 19% (branch S3_2)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -689,6 +689,11 @@ else
   CXXFLAGS="$CXXFLAGS -s USE_ICU=1"
 fi
 
+PKG_CHECK_MODULES([GLIB], [glib-2.0],,
+  [AC_MSG_ERROR([glib development files required])])
+CFLAGS="${CFLAGS} ${GLIB_CFLAGS}"
+LIBS="${LIBS} ${GLIB_LIBS}"
+
 dnl Should we build Qt5 versions of Qt programs?
 dnl This needs to be before C++ compiler check FC_WORKING_CXX, and
 dnl that in turn needs to be before FC_DEBUG that will depend on compiler


### PR DESCRIPTION
Starting freeciv-server does millions of utf8 to utf16 conversions for millions of case insensitive string comparisons consuming a great share of the cpu time spent to start the server. We are not talking 10%. A lot more.

Looking deeper into that code, the nation ruleset loading is doing some Schlemiel the Painter's Algorithm.

For only some 100 nations its loading rules, like conflict nations. For each such rule, its again going over all nations during a linear list lookup to get the nation for the  rule. And its doing the same conversions, always 2, and comparision over and over again. Its probably ending into some `O(n**2)` or `O(n**3)`.

Its not easy to fix the whole algorithm, esp, when i am unfamiliar with freeciv code.

First i tried to fix the string comparasion, or at least enhance its performance, by precalculating one of the comparing strings and reuse it.

Now  i have a better solution, far from perfect, but with introducing a simple hash table nation_rule_name to nation lookup we can already regain 19% startup time without any changes to the whole nation ruleset loading algorithm.

freeciv-server already links to glib:

```
$ ldd /home/michael/opt/freeciv-3.2-18ecf71d211c59d1d4d4a1c5b3776c88f3b52c6c/bin/freeciv-server|grep glib
	libglib-2.0.so.0 => /usr/lib/libglib-2.0.so.0 (0x000070e788e59000)
```

So i hope its fine to use glib for the hash table. glib can also do the utf8 string compare stuff instead of the utf16 stuff we currently do with icu lib. there is also hash table stuff in freeciv we could use, but freeciv doesnt make much use of it, so i guess its kinda dead code and we could as well use glib.

So let me know what you think of this.

This PoC is already regaining 19% startup time. The following data was created with `-march=native -O2` on Intel N5100. An AMD Ryzen system also showed 19%. To create it, i inserted an `exit(0);`, so the server exits when started after loading its stuff and going to main event loop, at this line:
https://github.com/freeciv/freeciv/blob/18ecf71d211c59d1d4d4a1c5b3776c88f3b52c6c/server/sernet.c#L539

```
$ poop /home/michael/opt/freeciv-3.2-18ecf71d211c59d1d4d4a1c5b3776c88f3b52c6c/bin/freeciv-server /home/michael/opt/freeciv-3.2-speedup2/bin/freeciv-server
Benchmark 1 (12 runs): /home/michael/opt/freeciv-3.2-18ecf71d211c59d1d4d4a1c5b3776c88f3b52c6c/bin/freeciv-server
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           447ms ± 9.49ms     437ms …  469ms          1 ( 8%)        0%
  peak_rss           77.5MB ±  500KB    76.6MB … 78.1MB          0 ( 0%)        0%
  cpu_cycles         1.02G  ± 17.0M      999M  … 1.05G           0 ( 0%)        0%
  instructions       2.36G  ± 1.40M     2.35G  … 2.36G           0 ( 0%)        0%
  cache_references   2.97M  ± 47.9K     2.89M  … 3.03M           0 ( 0%)        0%
  cache_misses       1.82M  ± 17.3K     1.80M  … 1.86M           0 ( 0%)        0%
  branch_misses      5.00M  ±  226K     4.70M  … 5.48M           0 ( 0%)        0%
Benchmark 2 (14 runs): /home/michael/opt/freeciv-3.2-speedup2/bin/freeciv-server
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           359ms ± 3.43ms     352ms …  364ms          0 ( 0%)        ⚡- 19.7% ±  1.3%
  peak_rss           77.4MB ±  512KB    76.8MB … 78.1MB          0 ( 0%)          -  0.1% ±  0.5%
  cpu_cycles          775M  ± 7.46M      762M  …  792M           0 ( 0%)        ⚡- 23.7% ±  1.0%
  instructions       1.68G  ± 1.93M     1.68G  … 1.68G           1 ( 7%)        ⚡- 28.8% ±  0.1%
  cache_references   2.81M  ± 57.6K     2.73M  … 2.92M           0 ( 0%)        ⚡-  5.3% ±  1.5%
  cache_misses       1.78M  ± 16.6K     1.76M  … 1.81M           0 ( 0%)        ⚡-  2.2% ±  0.8%
  branch_misses      3.87M  ±  142K     3.56M  … 3.98M           2 (14%)        ⚡- 22.6% ±  3.0%

$ /usr/bin/time -v /home/michael/opt/freeciv-3.2-18ecf71d211c59d1d4d4a1c5b3776c88f3b52c6c/bin/freeciv-server 
	User time (seconds): 0.36
	System time (seconds): 0.08
	Percent of CPU this job got: 99%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.45

$ /usr/bin/time -v /home/michael/opt/freeciv-3.2-speedup2/bin/freeciv-server 
	User time (seconds): 0.27
	System time (seconds): 0.08
	Percent of CPU this job got: 99%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.36
```

Let me know what you think of this, and how to proceed.