### PR TITLE
Speedup freeciv-gui-client (branch S3_2)

### DIFF
--- a/client/packhand.c
+++ b/client/packhand.c
@@ -2203,7 +2203,7 @@ void handle_set_topology(int topology_id, int wrap_id)
 
     ts_to_load = tileset_name_for_topology(topology_id);
 
-    if (ts_to_load != NULL && ts_to_load[0] != '\0') {
+    if (ts_to_load != NULL && ts_to_load[0] != '\0' && strcmp(tileset_basename(tileset), ts_to_load)) {
       tilespec_reread_frozen_refresh(ts_to_load);
     }
   }


### PR DESCRIPTION
When the client starts, it reads the tilespec gfx sprites.

When the server requests a topology set / change, the client throws away the tilespec and re-reads the new one.

load_sprite() was already caching, but doesnt cover this topology change / re-read case.

This PR adds a check, if the new topology tileset is the one already / currently loaded, and in this case does not re-read.

If the client is started and a game is started the server always sends a topology set / change, so this speedup helps a common case.

each `tilespec_reread_frozen_refresh()` on AMD Ryzen 5700G with `-march=native -O2` takes user 177ms sys 12ms