### PR TITLE
Fix mem leaks

### DIFF
--- a/client/gui-gtk-3.22/pages.c
+++ b/client/gui-gtk-3.22/pages.c
@@ -164,6 +164,7 @@ static void main_callback(GtkWidget *w, gpointer data)
 static gboolean intro_expose(GtkWidget *w, cairo_t *cr, gpointer *data)
 {
   static PangoLayout *layout;
+  PangoFontDescription* desc;
   static int width, height;
   static bool left = FALSE;
   GtkAllocation allocation;
@@ -177,8 +178,9 @@ static gboolean intro_expose(GtkWidget *w, cairo_t *cr, gpointer *data)
     const char *rev_ver;
 
     layout = pango_layout_new(gtk_widget_create_pango_context(w));
-    pango_layout_set_font_description(layout,
-         pango_font_description_from_string("Sans Bold 10"));
+    desc = pango_font_description_from_string("Sans Bold 10");
+    pango_layout_set_font_description(layout, desc);
+    pango_font_description_free(desc);
 
     rev_ver = fc_git_revision();
 

--- a/client/gui-gtk-3.22/themes.c
+++ b/client/gui-gtk-3.22/themes.c
@@ -59,7 +59,7 @@ void gui_load_theme(const char *directory, const char *theme_name)
   fc_snprintf(buf, sizeof(buf), "%s/%s/gtk-3.0/gtk.css", directory,
               theme_name);
 
-  gtk_css_provider_load_from_file(theme_provider, g_file_new_for_path(buf), &error);
+  gtk_css_provider_load_from_path(theme_provider, buf, &error);
 
   if (error != NULL) {
     g_warning("%s\n", error->message);

--- a/client/gui-gtk-4.0/pages.c
+++ b/client/gui-gtk-4.0/pages.c
@@ -169,6 +169,7 @@ static void intro_expose(GtkDrawingArea *w, cairo_t *cr,
                          int width, int height, gpointer data)
 {
   static PangoLayout *layout;
+  PangoFontDescription* desc;
   static int pwidth, pheight;
   static bool left = FALSE;
   GtkAllocation allocation;
@@ -182,8 +183,9 @@ static void intro_expose(GtkDrawingArea *w, cairo_t *cr,
     const char *rev_ver;
 
     layout = pango_layout_new(gtk_widget_create_pango_context(GTK_WIDGET(w)));
-    pango_layout_set_font_description(layout,
-         pango_font_description_from_string("Sans Bold 10"));
+    desc = pango_font_description_from_string("Sans Bold 10");
+    pango_layout_set_font_description(layout, desc);
+    pango_font_description_free(desc);
 
     rev_ver = fc_git_revision();
 

--- a/client/gui-gtk-4.0/themes.c
+++ b/client/gui-gtk-4.0/themes.c
@@ -58,7 +58,7 @@ void gui_load_theme(const char *directory, const char *theme_name)
   fc_snprintf(buf, sizeof(buf), "%s/%s/gtk-4.0/gtk.css", directory,
               theme_name);
 
-  gtk_css_provider_load_from_file(theme_provider, g_file_new_for_path(buf));
+  gtk_css_provider_load_from_path(theme_provider, buf);
 }
 
 /*************************************************************************//**

--- a/client/gui-gtk-5.0/pages.c
+++ b/client/gui-gtk-5.0/pages.c
@@ -169,6 +169,7 @@ static void intro_expose(GtkDrawingArea *w, cairo_t *cr,
                          int width, int height, gpointer data)
 {
   static PangoLayout *layout;
+  PangoFontDescription* desc;
   static int pwidth, pheight;
   static bool left = FALSE;
   GtkAllocation allocation;
@@ -182,8 +183,9 @@ static void intro_expose(GtkDrawingArea *w, cairo_t *cr,
     const char *rev_ver;
 
     layout = pango_layout_new(gtk_widget_create_pango_context(GTK_WIDGET(w)));
-    pango_layout_set_font_description(layout,
-         pango_font_description_from_string("Sans Bold 10"));
+    desc = pango_font_description_from_string("Sans Bold 10");
+    pango_layout_set_font_description(layout, desc);
+    pango_font_description_free(desc);
 
     rev_ver = fc_git_revision();
 

--- a/client/gui-gtk-5.0/themes.c
+++ b/client/gui-gtk-5.0/themes.c
@@ -58,7 +58,7 @@ void gui_load_theme(const char *directory, const char *theme_name)
   fc_snprintf(buf, sizeof(buf), "%s/%s/gtk-4.0/gtk.css", directory,
               theme_name);
 
-  gtk_css_provider_load_from_file(theme_provider, g_file_new_for_path(buf));
+  gtk_css_provider_load_from_path(theme_provider, buf);
 }
 
 /*************************************************************************//**


### PR DESCRIPTION
Fix leak of `GFile` in `client/gui-gtk-3.22/themes.c:gui_load_theme()`

branch: main

client: gui-gtk-3.22

Fixes the following leak reported by gcc leak sanitizer:
```
Indirect leak of 93 byte(s) in 1 object(s) allocated from:
    #0 0x73978defd891 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x73978a7bd14a in g_malloc (/usr/lib/libglib-2.0.so.0+0x6314a) (BuildId: 7b781c8d1a6e2161838c5d8f3bd797797c132753)
    #2 0x73978a7d341a in g_strdup (/usr/lib/libglib-2.0.so.0+0x7941a) (BuildId: 7b781c8d1a6e2161838c5d8f3bd797797c132753)
    #3 0x73978a79d07a in g_canonicalize_filename (/usr/lib/libglib-2.0.so.0+0x4307a) (BuildId: 7b781c8d1a6e2161838c5d8f3bd797797c132753)
    #4 0x73978a9dfa2f  (/usr/lib/libgio-2.0.so.0+0x135a2f) (BuildId: 7694fda88e539c80456f5f831eb4fc93adae2ca8)
    #5 0x739786b2e969  (/usr/lib/gio/modules/libgvfsdbus.so+0x1a969) (BuildId: 2a8d934e9b9dffacc29fa9985acb3225e7a30bbb)
    #6 0x5dab9f326cd1 in gui_load_theme ../../../client/gui-gtk-3.22/themes.c:62
    #7 0x5dab9f1bed35 in load_theme ../../client/themes_common.c:127
```