### PR TITLE
Fix mem leak in cityrep.c:cityrep_sort_func()

### DIFF
--- a/client/gui-gtk-3.22/cityrep.c
+++ b/client/gui-gtk-3.22/cityrep.c
@@ -1124,12 +1124,16 @@ static gint cityrep_sort_func(GtkTreeModel *model, GtkTreeIter *a,
                               GtkTreeIter *b, gpointer data)
 {
   gint col = GPOINTER_TO_INT(data);
-  const gchar *str1, *str2;
+  gchar *str1, *str2;
+  int i;
 
   gtk_tree_model_get(model, a, col, &str1, -1);
   gtk_tree_model_get(model, b, col, &str2, -1);
 
-  return cityrepfield_compare(str1, str2);
+  i = cityrepfield_compare(str1, str2);
+  g_free(str1);
+  g_free(str2);
+  return i;
 }
 
 /************************************************************************//**

--- a/client/gui-gtk-4.0/cityrep.c
+++ b/client/gui-gtk-4.0/cityrep.c
@@ -1152,12 +1152,16 @@ static gint cityrep_sort_func(GtkTreeModel *model, GtkTreeIter *a,
                               GtkTreeIter *b, gpointer data)
 {
   gint col = GPOINTER_TO_INT(data);
-  const gchar *str1, *str2;
+  gchar *str1, *str2;
+  int i;
 
   gtk_tree_model_get(model, a, col, &str1, -1);
   gtk_tree_model_get(model, b, col, &str2, -1);
 
-  return cityrepfield_compare(str1, str2);
+  i = cityrepfield_compare(str1, str2);
+  g_free(str1);
+  g_free(str2);
+  return i;
 }
 
 /************************************************************************//**

--- a/client/gui-gtk-5.0/cityrep.c
+++ b/client/gui-gtk-5.0/cityrep.c
@@ -1173,12 +1173,16 @@ static gint cityrep_sort_func(GtkTreeModel *model, GtkTreeIter *a,
                               GtkTreeIter *b, gpointer data)
 {
   gint col = GPOINTER_TO_INT(data);
-  const gchar *str1, *str2;
+  gchar *str1, *str2;
+  int i;
 
   gtk_tree_model_get(model, a, col, &str1, -1);
   gtk_tree_model_get(model, b, col, &str2, -1);
 
-  return cityrepfield_compare(str1, str2);
+  i = cityrepfield_compare(str1, str2);
+  g_free(str1);
+  g_free(str2);
+  return i;
 }
 
 /************************************************************************//**


### PR DESCRIPTION
Fix mem leak in `cityrep.c:cityrep_sort_func()`:

```
Direct leak of 4297836 byte(s) in 298585 object(s) allocated from:
    #0 0x77a1008fd891 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x77a0fd20114a in g_malloc (/usr/lib/libglib-2.0.so.0+0x6314a) (BuildId: 7b781c8d1a6e2161838c5d8f3bd797797c132753)
    #2 0x77a0fd21741a in g_strdup (/usr/lib/libglib-2.0.so.0+0x7941a) (BuildId: 7b781c8d1a6e2161838c5d8f3bd797797c132753)
    #3 0x77a0fd17666c  (/usr/lib/libgobject-2.0.so.0+0x3866c) (BuildId: 5af5e0f7d0a900ecb6083fbd71e22e5522d872e2)
    #4 0x77a0fdb060b9 in gtk_tree_model_get_valist (/usr/lib/libgtk-3.so.0+0x3060b9) (BuildId: 664be419f1dbdb168d0204fb57079f0b124ae952)
    #5 0x77a0fdb063f1 in gtk_tree_model_get (/usr/lib/libgtk-3.so.0+0x3063f1) (BuildId: 664be419f1dbdb168d0204fb57079f0b124ae952)
    #6 0x5e3d22316c2c in cityrep_sort_func ../../../client/gui-gtk-3.22/cityrep.c:1129

Direct leak of 3354288 byte(s) in 248025 object(s) allocated from:
    #0 0x77a1008fd891 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x77a0fd20114a in g_malloc (/usr/lib/libglib-2.0.so.0+0x6314a) (BuildId: 7b781c8d1a6e2161838c5d8f3bd797797c132753)
    #2 0x77a0fd21741a in g_strdup (/usr/lib/libglib-2.0.so.0+0x7941a) (BuildId: 7b781c8d1a6e2161838c5d8f3bd797797c132753)
    #3 0x77a0fd17666c  (/usr/lib/libgobject-2.0.so.0+0x3866c) (BuildId: 5af5e0f7d0a900ecb6083fbd71e22e5522d872e2)
    #4 0x77a0fdb060b9 in gtk_tree_model_get_valist (/usr/lib/libgtk-3.so.0+0x3060b9) (BuildId: 664be419f1dbdb168d0204fb57079f0b124ae952)
    #5 0x77a0fdb063f1 in gtk_tree_model_get (/usr/lib/libgtk-3.so.0+0x3063f1) (BuildId: 664be419f1dbdb168d0204fb57079f0b124ae952)
    #6 0x5e3d22316c4c in cityrep_sort_func ../../../client/gui-gtk-3.22/cityrep.c:1130
```