### PR TITLE
meson: use `feature` option type

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -172,10 +172,11 @@ json-protocol (boolean):
   Build json-protocol support in. Json-protocol is an alternative to the default
   raw-protocol between freeciv server and client.
 
-syslua ('try'/'true'/'false')
+syslua ('auto'/'enabled'/'disabled')
   Whether to use lua from the system, or to build lua included in freeciv
-  source tree. The default is 'try' to use lua from the system if possible,
-  but fallback to using freeciv's included one if not found from system.
+  source tree. The default is to 'auto'matically use system lua if
+  found. If you want to disable it, set this to 'disabled'.
+  If you want to fail if it is not found set this to 'enabled'.
 
 sys-tolua-cmd (boolean):
   Whether to use tolua command from the system, or to build one
@@ -184,13 +185,17 @@ sys-tolua-cmd (boolean):
   When cross-compiling, this setting is ignored, and tolua is
   always used from the build system.
 
-mwand ('try'/'true'/'false')
+mwand ('auto'/'enabled'/'disabled')
   Whether to build against MagickWand to have support for additional
-  mapimg formats. The default is 'try' to enable the support if possible.
+  mapimg formats. The default is to 'auto'matically use the library if
+  found. If you want to disable it, set this to 'disabled'.
+  If you want to fail if it is not found set this to 'enabled'.
 
-readline ('try'/'true'/'false')
+readline ('auto'/'enabled'/'disabled')
   Whether to enable readline functionality on server.
-  The default is 'try' to enable it if suitable readline found.
+  The default is to 'auto'matically use the library if
+  found. If you want to disable it, set this to 'disabled'.
+  If you want to fail if it is not found set this to 'enabled'.
 
 audio ('none'/'sdl2'/'sdl3'):
   What kind of sound support should be built to the clients. Defaults to sdl2.

--- a/meson.build
+++ b/meson.build
@@ -558,20 +558,10 @@ else
   charset_dep = []
 endif
 
-rl_req = get_option('readline')
-if rl_req != 'false'
-  readline_dep = c_compiler.find_library('readline', dirs: cross_lib_path,
-                                         required:false)
-
-  if readline_dep.found() and c_compiler.has_function('rl_completion_suppress_append',
-                                                      dependencies: readline_dep,
-                                                      args: ['-O'])
+# Readline 4.3 ensures that we have `rl_completion_suppress_append`
+readline_dep = dependency('readline', version: '>= 4.3', required: get_option('readline'))
+if readline_dep.found()
     pub_conf_data.set('FREECIV_HAVE_LIBREADLINE', 1)
-  elif rl_req == 'true'
-    error('Readline support requested but not found.')
-  endif
-else
-  readline_dep = []
 endif
 
 if c_compiler.has_header('bzlib.h', args: header_arg)
@@ -686,68 +676,58 @@ else
     error('Mandatory header zlib.h not found!')
   endif
   icu_dep = dependency('icu-uc')
-  syslua = get_option('syslua')
-  if syslua != 'false'
-    lua_dep_tmp = dependency('lua-5.4', 'lua-54', 'lua54', 'lua5.4', required:false)
-  endif
 endif
 
 # Set unconditionally, as it was checked as hard requirement
 pub_conf_data.set('FREECIV_HAVE_LIBZ', 1)
 
-mw_req = get_option('mwand')
+mw_dep = dependency('MagickWand', 'MagickWand-6.Q16HDRI', required: get_option('mwand'))
 mw_extra_dep = []
-if mw_req != 'false'
-  mw_dep = dependency('MagickWand', version : '>= 7.0', required : false)
-  if mw_dep.found()
+if mw_dep.found()
+  if mw_dep.version().version_compare('>= 7.0')
     pub_conf_data.set('FREECIV_MWAND7', '1')
     mwand_incl = '#include <MagickWand/MagickWand.h>'
+  elif mw_dep.version().version_compare('>= 6.0')
+    pub_conf_data.set('FREECIV_MWAND6', '1')
+    mwand_incl = '#include <wand/MagickWand.h>'
   else
-    mw_dep = dependency('MagickWand', version : '>= 6.0', required : false)
-    if not mw_dep.found()
-      mw_dep = dependency('MagickWand-6.Q16HDRI', required: false)
-    endif
-    if mw_dep.found()
-      mwand_incl = '#include <wand/MagickWand.h>'
-      mwand_incl = '#include <wand/MagickWand.h>'
-    endif
+    error('MagickWand version 6.0 or newer is required.')
   endif
-  if mw_dep.found()
-    if not c_compiler.links(mwand_incl + '''
-int main(void) { MagickWandGenesis(); }''',
+  if c_compiler.links(
+    mwand_incl + '\nint main(void) { MagickWandGenesis(); }',
     name: 'mwand links',
-    dependencies: mw_dep)
-      mw_extra_dep = [c_compiler.find_library('urlmon', dirs: cross_lib_path,
-                                              required: false),
-                      c_compiler.find_library('gdi32', dirs: cross_lib_path,
-                                              required: false)]
-      if c_compiler.links(mwand_incl + '''
-int main(void) { MagickWandGenesis(); }''',
-      name: 'mwand links',
-      dependencies: [mw_dep, mw_extra_dep, zlib_dep, lzma_dep, net_dep])
-        priv_conf_data.set('HAVE_MAPIMG_MAGICKWAND', '1')
-      elif mw_req == 'true'
-        error('MagickWand support requested but not found.')
-      else
-        mw_dep = []
-        mw_extra_dep = []
-      endif
-    else
+    dependencies: mw_dep,
+  )
+    priv_conf_data.set('HAVE_MAPIMG_MAGICKWAND', '1')
+  else
+    mw_extra_dep = [
+      c_compiler.find_library(
+        'urlmon',
+        dirs: cross_lib_path,
+        required: false,
+      ),
+      c_compiler.find_library(
+        'gdi32',
+        dirs: cross_lib_path,
+        required: false,
+      ),
+    ]
+    if c_compiler.links(
+      mwand_incl + '\nint main(void) { MagickWandGenesis(); }',
+      name: 'mwand links with additional deps',
+      dependencies: [mw_dep, mw_extra_dep, zlib_dep, lzma_dep, net_dep],
+    )
       priv_conf_data.set('HAVE_MAPIMG_MAGICKWAND', '1')
+    else
+      error('MagickWand found but could not link sanity check.')
     endif
-  elif mw_req == 'true'
-    error('MagickWand support requested but not found.')
   endif
-else
-  mw_dep = []
 endif
 
-if syslua != 'false' and lua_dep_tmp.found()
-  lua_inc_path = []
+lua_dep = dependency('lua-5.4', 'lua-54', 'lua54', 'lua5.4', required: get_option('syslua'))
+if lua_dep.found()
+  lua_inc_path = ''
   lua_sources = []
-  lua_dep = lua_dep_tmp
-elif syslua == 'true'
-  error('Syslua requested but not found.')
 else
   lua_inc_path = 'dependencies/lua-5.4/src'
   lua_sources = [

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -26,8 +26,8 @@ option('json-protocol',
        description: 'Build in json-protocol support')
 
 option('syslua',
-       type: 'combo',
-       choices: ['try', 'true', 'false'],
+       type: 'feature',
+       value: 'auto',
        description: 'Use lua from system')
 
 option('sys-tolua-cmd',
@@ -36,13 +36,13 @@ option('sys-tolua-cmd',
        description: 'Use tolua cmd from the system even for native builds')
 
 option('mwand',
-       type: 'combo',
-       choices: ['try', 'true', 'false'],
+       type: 'feature',
+       value: 'auto',
        description: 'Build MagickWand support to mapimg')
 
 option('readline',
-       type: 'combo',
-       choices: ['try', 'true', 'false'],
+       type: 'feature',
+       value: 'auto',
        description: 'Enable readline functionality')
 
 option('audio',

--- a/platforms/emscripten/emsbuild.sh
+++ b/platforms/emscripten/emsbuild.sh
@@ -50,7 +50,7 @@ if ! CC=emcc CXX=em++ AR=emar meson setup \
      -Ddefault_library=static \
      -Ddebug=true \
      -Daudio=none \
-     -Dmwand=false \
+     -Dmwand=disabled \
      -Dtools=[] \
      -Dclients=stub,sdl2 \
      -Dfcmp=[] \

--- a/platforms/windows/installer_msys2/Makefile.meson
+++ b/platforms/windows/installer_msys2/Makefile.meson
@@ -138,7 +138,7 @@ installer-common: install-freeciv-$(GUI) install-env-$(GUI)
 install-freeciv-common: clean-install-client-arch
 	# Create build directory
 	mkdir -p $(BUILD_DIR)/$(WINARCH)-client-$(GUI)
-	cd $(BUILD_DIR)/$(WINARCH)-client-$(GUI); meson setup $(IMSYS2_DIR)/../../.. -Dprefix=$(IMSYS2_DIR)/$(INST_DIR)/$(WINARCH)-client-$(GUI) -Dfollowtag='windows-S3_4' -Dclients=$(CLIENT) -Dfcmp=$(FCMP) -Dtools=manual,ruleup -Dreadline=false -Dcacert-path='./ssl/certs/ca-bundle.crt' -Dmin-win-ver=$(MIN_WIN_VER) -Dsyslua=false $(EXTRA_CONFIG)
+	cd $(BUILD_DIR)/$(WINARCH)-client-$(GUI); meson setup $(IMSYS2_DIR)/../../.. -Dprefix=$(IMSYS2_DIR)/$(INST_DIR)/$(WINARCH)-client-$(GUI) -Dfollowtag='windows-S3_4' -Dclients=$(CLIENT) -Dfcmp=$(FCMP) -Dtools=manual,ruleup -Dreadline=disabled -Dcacert-path='./ssl/certs/ca-bundle.crt' -Dmin-win-ver=$(MIN_WIN_VER) -Dsyslua=disabled $(EXTRA_CONFIG)
 	cd $(BUILD_DIR)/$(WINARCH)-client-$(GUI); ninja
 	cd $(BUILD_DIR)/$(WINARCH)-client-$(GUI); ninja install
 	cd $(BUILD_DIR)/$(WINARCH)-client-$(GUI); ninja langstat_core.txt
@@ -155,7 +155,7 @@ install-freeciv-common: clean-install-client-arch
 install-ruledit-common: clean-ruledit-install-arch
 	# Create build directory
 	mkdir -p $(BUILD_DIR)/$(WINARCH)-ruledit-$(GUI)
-	cd $(BUILD_DIR)/$(WINARCH)-ruledit-$(GUI); meson setup $(IMSYS2_DIR)/../../.. -Dprefix=$(IMSYS2_DIR)/$(INST_DIR)/$(WINARCH)-ruledit-$(GUI) -Dfollowtag='windows-S3_4' -Dclients=[] -Dfcmp=[] -Dserver=disabled -Dtools=ruledit -Dreadline=false -Dcacert-path='./ssl/certs/ca-bundle.crt' -Dmin-win-ver=$(MIN_WIN_VER) -Dsyslua=false $(EXTRA_CONFIG)
+	cd $(BUILD_DIR)/$(WINARCH)-ruledit-$(GUI); meson setup $(IMSYS2_DIR)/../../.. -Dprefix=$(IMSYS2_DIR)/$(INST_DIR)/$(WINARCH)-ruledit-$(GUI) -Dfollowtag='windows-S3_4' -Dclients=[] -Dfcmp=[] -Dserver=disabled -Dtools=ruledit -Dreadline=disabled -Dcacert-path='./ssl/certs/ca-bundle.crt' -Dmin-win-ver=$(MIN_WIN_VER) -Dsyslua=disabled $(EXTRA_CONFIG)
 	cd $(BUILD_DIR)/$(WINARCH)-ruledit-$(GUI); ninja
 	cd $(BUILD_DIR)/$(WINARCH)-ruledit-$(GUI); ninja install
 	cd $(BUILD_DIR)/$(WINARCH)-ruledit-$(GUI); ninja langstat_core.txt langstat_ruledit.txt

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -89,7 +89,7 @@ meson setup .. \
   -Dqtver=qt6x \
   -Ddebug=true \
   -Dtools=ruledit,manual,ruleup \
-  -Dsyslua=true \
+  -Dsyslua=enabled \
   -Dclients=gtk3.22,sdl2,gtk4,qt,stub,gtk4x \
   -Dfcmp=gtk3,gtk4,qt,cli \
   -Dfollowtag=macos \


### PR DESCRIPTION
The meson `feature` option type can replace the `combo` type with `try`, `true`, `false` currently used for dependencies.

`features` are tri-state, come with useful helpers to reduce boilerplate, and may be directly referenced in the `required` field of dependencies to simplify conditional logic: a dependency check that `requires` a `disabled` feature always returns `not found`.

This commit attempts to use dependency objects directly for cross builds rather than `cc.find_library(... cross_path)`

Additionally update CI scripts to use `enabled/disabled` instead of `true/false'.

Bug: [RM#1303](https://redmine.freeciv.org/issues/1303)
See-also: #71 