### PR TITLE
meson: use `warning_level` default option instead of `-Wall`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
-
 project('freeciv', ['c'],
         meson_version: '>= 0.63.0',
-        version : run_command('fc_version', check : true).stdout())
+        version : run_command('fc_version', check : true).stdout(),
+        default_options: ['warning_level=1'])
 
 c_compiler = meson.get_compiler('c')
 
@@ -23,7 +23,6 @@ c_args = [
   ]
 
 c_cpp_args = [
-  '-Wall',
   '-Wmissing-declarations',
   '-Wpointer-arith',
   '-Wcast-align',


### PR DESCRIPTION
We can set the warning level to the equivalent of `-Wall` by default using project options, while enabling users or downstreams to set a desired warning level if they so choose.

This will also reduce noise during the configure stage as Meson warns about `-Wall` for each compiler.

Bug: [RM#1316](https://redmine.freeciv.org/issues/1316)