### PR TITLE
gtk3.22: Set prgname to application ID

### DIFF
--- a/client/gui-gtk-3.22/gui_main.c
+++ b/client/gui-gtk-3.22/gui_main.c
@@ -1900,6 +1900,8 @@ int ui_main(int argc, char **argv)
       return EXIT_FAILURE;
     }
 
+    g_set_prgname("org.freeciv.gtk322");
+
     help_system_init();
 
     dlg_tab_provider_prepare();

--- a/tools/fcmp/mpgui_gtk3.c
+++ b/tools/fcmp/mpgui_gtk3.c
@@ -592,6 +592,8 @@ int main(int argc, char *argv[])
 
     /* Process GTK arguments */
     if (gtk_init_check(&ui_options, &argv)) {
+      g_set_prgname("org.freeciv.gtk3.mp");
+
       toplevel = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 
       gtk_widget_realize(toplevel);


### PR DESCRIPTION
Using the application ID ensures that Wayland compositors could match the window with the application and show the appropriate icon for them.

This is needed only for the GTK3 client.

References:
- https://honk.sigxcpu.org/con/GTK__and_the_application_id.html
- https://docs.gtk.org/gtk4/migrating-3to4.html#set-a-proper-application-id