### PR TITLE
Drop the self-assignment at the top of spy_steal_popup_shared

### DIFF
--- a/client/gui-gtk-3.22/action_dialog.c
+++ b/client/gui-gtk-3.22/action_dialog.c
@@ -945,8 +945,6 @@ static void spy_steal_popup_shared(GtkWidget *w, gpointer data)
 {
   struct action_data *args = (struct action_data *)data;
 
-  args->act_id = args->act_id;
-
   struct city *pvcity = game_city_by_number(args->target_city_id);
   struct player *pvictim = NULL;
 

--- a/client/gui-gtk-4.0/action_dialog.c
+++ b/client/gui-gtk-4.0/action_dialog.c
@@ -942,8 +942,6 @@ static void spy_steal_popup_shared(GtkWidget *w, gpointer data)
 {
   struct action_data *args = (struct action_data *)data;
 
-  args->act_id = args->act_id;
-
   struct city *pvcity = game_city_by_number(args->target_city_id);
   struct player *pvictim = NULL;
 

--- a/client/gui-gtk-5.0/action_dialog.c
+++ b/client/gui-gtk-5.0/action_dialog.c
@@ -1032,8 +1032,6 @@ static void spy_steal_popup_shared(GtkWidget *w, gpointer data)
 {
   struct action_data *args = (struct action_data *)data;
 
-  args->act_id = args->act_id;
-
   struct city *pvcity = game_city_by_number(args->target_city_id);
   struct player *pvictim = NULL;
 


### PR DESCRIPTION
`spy_steal_popup_shared` starts by assigning `args->act_id` to itself, in all three gtk clients. The callback only gets `GtkWidget *w` and `gpointer data`, so there is nothing on the other side that could have been meant there, and the field is read further down unchanged.

The three copies are identical down to the blank line around them, which is what made me look at all of them rather than just the one the check pointed at.
