### PR TITLE
fix groff error in freeciv-client(6) manpage

### DIFF
--- a/doc/man/freeciv-client.6.in
+++ b/doc/man/freeciv-client.6.in
@@ -53,7 +53,7 @@ documentation. It also accepts
 .B freeciv-sdl2
 accepts the following parameters following \fB\-\-\fP:
 .B [ \-f|\-\-fullscreen ] \
-[ \-F|\-\-Font \fsize\fP ] \
+[ \-F|\-\-Font \fIsize\fP ] \
 [ \-h|\-\-help ] \
 [ \-s|\-\-swrenderer ] \
 [ \-t|\-\-theme \fIstring\fP ]
@@ -61,7 +61,7 @@ accepts the following parameters following \fB\-\-\fP:
 .B freeciv-sdl3
 accepts the following parameters following \fB\-\-\fP:
 .B [ \-f|\-\-fullscreen ] \
-[ \-F|\-\-Font \fsize\fP ] \
+[ \-F|\-\-Font \fIsize\fP ] \
 [ \-h|\-\-help ] \
 [ \-t|\-\-theme \fIstring\fP ]
 


### PR DESCRIPTION
found with the lintian tool, the *I* in \fI was missing to switch to italic mode.

```
W: freeciv-data: groff-message troff:<standard input>:59: warning: cannot select font 's' [usr/share/man/man6/freeciv-client.6.gz:1] 
W: freeciv-data: groff-message troff:<standard input>:66: warning: cannot select font 's' [usr/share/man/man6/freeciv-client.6.gz:2]
```