### PR TITLE
gtk4: synchronize update_animation with idle tick.

### DIFF
--- a/client/gui-gtk-4.0/gui_main.c
+++ b/client/gui-gtk-4.0/gui_main.c
@@ -224,6 +224,10 @@ static void free_unit_table(void);
 
 static void adjust_default_options(void);
 
+static gboolean animation_tick_cb(GtkWidget *widget,
+                                  GdkFrameClock *frame_clock,
+                                  gpointer user_data);
+
 static float zoom_steps_custom[] = {
   -1.0, 0.13, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 2.5, 3.0, 4.0, -1.0
 };
@@ -1513,6 +1517,9 @@ static void setup_widgets(void)
   g_signal_connect(map_canvas, "resize",
                    G_CALLBACK(map_canvas_resize), NULL);
 
+  /* Synchronize animation updates with the tick (improve performances) */
+  gtk_widget_add_tick_callback(map_canvas, animation_tick_cb, NULL, NULL);
+
   mc_controller = gtk_event_controller_key_new();
   g_signal_connect(mc_controller, "key-pressed",
                    G_CALLBACK(toplevel_key_press_handler), NULL);
@@ -2427,14 +2434,16 @@ void add_idle_callback(void (callback)(void *), void *data)
 }
 
 /**********************************************************************//**
-  Add idle callback for updating animations.
+  Update animations if needed on the current GUI tick.
 **************************************************************************/
-void animation_idle_cb(void *data)
+static gboolean animation_tick_cb(GtkWidget *widget,
+                                  GdkFrameClock *frame_clock,
+                                  gpointer user_data)
 {
   if (get_current_client_page() == PAGE_GAME) {
     update_animation();
-    add_idle_callback(animation_idle_cb, NULL);
   }
+  return G_SOURCE_CONTINUE; /* keep animation call back running */
 }
 
 /**********************************************************************//**

--- a/client/gui-gtk-4.0/gui_main.h
+++ b/client/gui-gtk-4.0/gui_main.h
@@ -37,7 +37,6 @@
 #define GUI_GTK_DEFAULT_THEME_NAME FC_GTK4_DEFAULT_THEME_NAME
 
 void main_message_area_resize(void *data);
-void animation_idle_cb(void *data);
 
 /* Network string charset conversion */
 gchar *ntoh_str(const gchar *netstr);

--- a/client/gui-gtk-4.0/pages.c
+++ b/client/gui-gtk-4.0/pages.c
@@ -3603,7 +3603,6 @@ void real_set_client_page(enum client_pages new_page)
     center_on_something();
     mapview_thaw();
     add_idle_callback(main_message_area_resize, NULL);
-    add_idle_callback(animation_idle_cb, NULL);
     break;
   case PAGE_NETWORK:
     update_network_lists();


### PR DESCRIPTION
 in GTK4 you should not g_idle_add yourself during idle loop execution.

 see RM #2221 for discussion of this specific proposal.
 see RM #2186 (global)

Indentation has been updated as requested (at least I hope I get it right :).